### PR TITLE
(fix) View Resource links in Node View are still functional after resource addition

### DIFF
--- a/client/src/js/components/D3Graph.jsx
+++ b/client/src/js/components/D3Graph.jsx
@@ -46,8 +46,8 @@ ns._scales = function(el, domain) {
   if (!domain) {
     return null;
   }
-  console.log('offSetWidth', el.offsetWidth);
-  console.log('offSetHeight', el.offsetHeight);
+  // console.log('offSetWidth', el.offsetWidth);
+  // console.log('offSetHeight', el.offsetHeight);
 
   var width = el.offsetWidth;
   var height = el.offsetHeight;

--- a/client/src/js/components/NewResourceForm.jsx
+++ b/client/src/js/components/NewResourceForm.jsx
@@ -36,8 +36,10 @@ var NewResourceForm = React.createClass({
   },
 
   handleSave: function() {
+    // this call's NewResourceView's onSave method
     this.props.onSave(this.state.resourceName, this.state.resourceAuthor, this.state.resourceType, this.state.resourceURL, this.state.resourceDesc, this.props.id);
     if (!this.props.id) {
+      // this is then called since there is no id
       this.refs.newResourceForm.getDOMNode().value = '';
       this.setState({resourceName: '', resourceAuthor: '', resourceType: '', resourceURL: '', resourceDesc: ''});
     }

--- a/client/src/js/components/ResourceList.jsx
+++ b/client/src/js/components/ResourceList.jsx
@@ -17,16 +17,14 @@ var ResourceList = React.createClass({
   },
 
   addResource: function(info) {
-    //console.log('inaddResource', this.props.resources.concat());
-    console.log('inadd', info);
     GraphActions.resourceToSide(info);
   },
 
   render: function() {
     var self = this;
-    var resources = this.props.resources.concat();
+    var resources = this.props.resources;
+    console.log('resources', resources);
     var resourceNodes = resources.map(function(resource) {
-      console.log('resource', resource);
       resource.addResource = function(){
         var info = {
           name: resource.name,
@@ -36,7 +34,7 @@ var ResourceList = React.createClass({
       };
       
       resource.rating = '0';
-      resource.url = <a href={resource.url}>View Resource</a>;
+      resource.link = <a href={resource.url}>View Resource</a>;
       resource.addresource = <RaisedButton label="Add" secondary={true} onClick={resource.addResource} />
       return (
         <Resource key={resource._id} active={self.state.activeResourceId===resource._id} resource={resource} onEdit={self.props.onEdit} onSelect={self.setActiveResource}/>
@@ -57,7 +55,7 @@ var ResourceList = React.createClass({
             {key: 'rating', label: 'Rating'},
             {key: 'type', label: 'Type'},
             {key: 'description', label: 'Description'},
-            {key: 'url', label: 'View Resource'},
+            {key: 'link', label: 'View Resource'},
             {key: 'addresource', label: 'Add to Curriculum'}
           ]} />
       </div>

--- a/client/src/js/components/ResourceListBox.jsx
+++ b/client/src/js/components/ResourceListBox.jsx
@@ -17,6 +17,7 @@ var ResourceListBox = React.createClass({
   },
 
   updateState: function(data) {
+    console.log('list box data', data);
     this.setState({
       resources: data
     });
@@ -40,7 +41,7 @@ var ResourceListBox = React.createClass({
     return (
       <div className="col-md-4">
         <div className="centered"><a href="" onClick={this.onAdd}>Add New</a></div>
-        <ResourceList ref="resourceListView" resources={this.state.resources} onEdit={this.props.onEdit} />
+        <ResourceList ref="resourceList" resources={this.state.resources} onEdit={this.props.onEdit} />
       </div>
     )
   }

--- a/client/src/js/stores/GraphStore.jsx
+++ b/client/src/js/stores/GraphStore.jsx
@@ -128,18 +128,6 @@ var GraphStore = Reflux.createStore({
     // this.pushChanges();
   },
 
-  getJobs: function() {
-    // this.load(); //req to /api/listings
-    // return _jobs;
-  },
-
-  getJob: function(id) {
-    // for (var i = 0; i < _jobs.length; i++) {
-    //   if(_jobs._id === id) {
-    //     return jobs[i];
-    //   }
-    // }
-  }
 });
 
 module.exports = GraphStore;

--- a/client/src/js/stores/ResourceStore.jsx
+++ b/client/src/js/stores/ResourceStore.jsx
@@ -7,7 +7,6 @@ var ResourceStore = Reflux.createStore({
   nodeId: '1',
 
   init: function() {
-    //this.load()
     //Here we listen to actions and register callbacks
     this.listenTo(NodeResourceActions.createResource, this.onCreate);
     this.listenTo(NodeResourceActions.editResource, this.onEdit);
@@ -21,7 +20,7 @@ var ResourceStore = Reflux.createStore({
     $.ajax({
       type: "GET",
       dataType: 'json',
-      url: './api/node/resources/' + this.nodeId, // localhost for local testing
+      url: './api/node/resources/' + this.nodeId,
     }).then(function(data){
       _resources = data; //push data to store
       // set this.nodeId here !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
@@ -35,7 +34,6 @@ var ResourceStore = Reflux.createStore({
   updateNodeId: function(id) {
     this.nodeId = id;
     this.load();
-    // this.trigger(nodeId);
   },
 
   nodeIsClicked: function(data) {
@@ -62,18 +60,13 @@ var ResourceStore = Reflux.createStore({
       url: './api/resource',
       data: data
     }).then(function(data) {
-      // console.log('.then from ResourceStore POST', data);
       _resources.push(data);
-      // context.trigger(data);
+      // .load() method triggers ResourceStore already
       context.load();
       }, function(error){
       console.log('Error on ResourceStore.onCreate');
       console.error(error);
     });
-
-    //Trigger an event once done so that our components can update
-    //Also pass the modified list of resources
-    // this.trigger(_resources);
   },
 
   onEdit: function(note) {


### PR DESCRIPTION
- Bug fix
  - Renamed resource.url to resource.link to avoid nesting <a> tags
- Minor code cleanup
  - Delete various console.logs as well as a few extraneous comments
  - Delete .concat() on line 25 of ResourceList.jsx since it was taking no arguments
